### PR TITLE
Always run post step

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -77,4 +77,3 @@ runs:
   using: node16
   main: dist/main.js
   post: dist/post.js
-  post-if: success()


### PR DESCRIPTION
Great action that is simple and convenient to use. The only issue I had was that it is not uploading my dependencies on failure of some other unrelated step. The workaround would be to have the action in its own job, but it does not seem so common or desired (at least initially or for simple projects).