### PR TITLE
Use node24.

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -81,7 +81,7 @@ outputs:
       not requested, then this will be an empty string.
 
 runs:
-  using: node20
+  using: node24
   main: dist/main.js
   post: dist/post.js
   post-if: success() || env.SETUP_VCPKG_SAVE_ALWAYS == 'true'


### PR DESCRIPTION
**Why**
As described in #11, Github Actions started to warn about deprecating the usage of Node 20 in actions.

Fixes #11.

**What changed**
Changed the node version in action.yaml.

I don't know if further changes to the scripts themselves are required though.